### PR TITLE
ci: disable checkout credential persistence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install Rust (${{ matrix.version.version }})
         uses: actions-rust-lang/setup-rust-toolchain@v1.17.0


### PR DESCRIPTION
Disable checkout credential persistence in the workflows to prevent later steps from reusing the checkout token. git diff --check and git show --check HEAD pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration checkout configuration to avoid persisting Git credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->